### PR TITLE
add assertion validation to DTOTransformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # rpc-objects
 Component for UFO-Tech RPC Library
+
+### Example DTO with Assertions
+```php
+namespace App\DTO;
+
+use Ufo\RpcObject\DTO\ArrayConstructibleTrait;
+use Ufo\RpcObject\DTO\ArrayConvertibleTrait;
+use Ufo\RpcObject\DTO\IArrayConstructible;
+use Ufo\RpcObject\DTO\IArrayConvertible;
+use Symfony\Component\Validator\Constraints as Assert;
+use Ufo\RpcObject\RPC;
+
+class CarDTO implements IArrayConvertible, IArrayConstructible
+{
+    use ArrayConstructibleTrait, ArrayConvertibleTrait;
+
+    public function __construct(
+        #[RPC\Assertions([new Assert\NotBlank(), new Assert\Length(min: 2, max: 50)])]
+        public string $brand,
+        
+        #[RPC\Assertions([new Assert\NotBlank(), new Assert\Length(min: 1, max: 50)])]
+        public string $model,
+
+        #[RPC\Assertions([new Assert\Range(min: 1886, max: 2100)])]
+        public int $year,
+
+        #[RPC\Assertions([new Assert\Range(min: 0)])]
+        public int $mileage = 0
+    ) {}
+}
+```

--- a/src/RPC/Assertions.php
+++ b/src/RPC/Assertions.php
@@ -6,7 +6,7 @@ use Attribute;
 use Symfony\Component\Validator\Constraint;
 use Ufo\RpcObject\Transformer\Transformer;
 
-#[Attribute(Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 final readonly class Assertions
 {
     public string $constructorArgs;


### PR DESCRIPTION
Improvements and fixes for RPC assertions and DTO validation

Changes introduced:
- 🛠 Extended RPC\assertions support - now assertions can be applied not only to parameters, but also to properties.
- 📄 Updated README - added a DTO example demonstrating the new assertion capabilities.
- ✅ Improved validation in DTOTransformer - now the validation checks assertions and throws a RpcBadParamException for the first failed assertion.